### PR TITLE
Implement std::convert::TryFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Example
 =======
 
 ```rust
-#[macro_use]
-extern crate derive_try_from_primitive;
+use std::convert::TryFrom;
+use derive_try_from_primitive::TryFromPrimitive;
 
 
 #[derive(TryFromPrimitive)]
@@ -14,6 +14,20 @@ enum Foo {
     Quix = 200,
 }
 
+// Generated Code:
+impl core::convert::TryFrom<u16> for Foo {
+  type Error = u16;
+
+  fn try_from(n: 16) -> Result<Self, Self::Error> {
+    match n {
+      0 => Ok(Foo::Bar),
+      100 => Ok(Foo::Baz),
+      200 => Ok(Foo::Quix),
+      _ => Err(n),
+    }
+  }
+}
+
 fn main() {
   let bar = Foo::try_from(0);
   let baz = Foo::try_from(100);
@@ -22,6 +36,8 @@ fn main() {
   assert_eq!(bar.unwrap() as u16, 0);
   assert_eq!(baz.unwrap() as u16, 100);
   assert_eq!(quix.unwrap() as u16, 200);
-  assert!(bad.is_none());
+  if let Err(value) = bad {
+    assert_eq!(value, 300, "Input is returned for convenience");
+  }
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use syn::ConstExpr::Lit;
 fn try_from_primitive(ast: &syn::MacroInput, variants: &[syn::Variant]) -> quote::Tokens {
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let doc = format!("TryFrom for `{}`.", name);
+    let doc = format!("Generated impl [TryFrom](std::convert::TryFrom) for `{}`.", name);
     let lint_attrs = collect_parent_lint_attrs(&ast.attrs);
     let lint_attrs = quote![#(#lint_attrs),*];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,43 +54,43 @@ fn try_from_primitive(ast: &syn::MacroInput, variants: &[syn::Variant]) -> quote
             match ident.as_ref() {
                 "u8" => {
                     let discr = discr.unwrap() as u8;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "u16" => {
                     let discr = discr.unwrap() as u16;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "u32" => {
                     let discr = discr.unwrap() as u32;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "u64" => {
                     let discr = discr.unwrap() as u64;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "usize" => {
                     let discr = discr.unwrap() as usize;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "i8" => {
                     let discr = discr.unwrap() as i8;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "i16" => {
                     let discr = discr.unwrap() as i16;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "i32" => {
                     let discr = discr.unwrap() as i32;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "i64" => {
                     let discr = discr.unwrap() as i64;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 "isize" => {
                     let discr = discr.unwrap() as isize;
-                    quote!(#discr => Some(#name::#v_name))
+                    quote!(#discr => Ok(#name::#v_name))
                 }
                 ty => {
                     panic!("#[derive(TryFromPrimitive)] does not support enum repr type {:?}",
@@ -99,20 +99,22 @@ fn try_from_primitive(ast: &syn::MacroInput, variants: &[syn::Variant]) -> quote
             }
         } else {
             let discr = discr.unwrap() as usize;
-            quote!(#discr => Some(#name::#v_name))
+            quote!(#discr => Ok(#name::#v_name))
         }
     });
     let match_arms = quote![#(#match_arms),*];
 
 
     quote! {
-        impl #impl_generics #name #ty_generics #where_clause {
+        impl #impl_generics core::convert::TryFrom<#repr> for #name #ty_generics #where_clause {
+            type Error = #repr;
+
             #[doc = #doc]
             #lint_attrs
-            pub fn try_from(n: #repr) -> Option<#name> {
+            fn try_from(n: #repr) -> Result<Self, Self::Error> {
                 match n {
                     #match_arms,
-                    _ => None
+                    _ => Err(n)
                 }
             }
         }


### PR DESCRIPTION
Generate an implementation of core::convert::TryFrom, returning an error containing the input value if a match cannot be found. Addresses #2 .

This breaks the existing API, but it is in line with hand-built implementations of TryFrom<T>. The original value is returned (as opposed to a custom error type or formatted string) to allow consumers to  handle their own error messaging or perform more sophisticated recovery.
