### PR TITLE
Use core::result::Result specifically

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ fn try_from_primitive(
 
             #[doc = #doc]
             #lint_attrs
-            fn try_from(n: #repr) -> Result<Self, Self::Error> {
+            fn try_from(n: #repr) -> core::result::Result<Self, Self::Error> {
                 match n {
                     #match_arms,
                     _ => Err(n)


### PR DESCRIPTION
Having a type in scope called `Result` will break the derive macro, as it generates code that refers to `Result`, assuming it is the one from core.

This fixes the bug by specifying `core::result::Result` instead of relying on the user not having shadowed the one in prelude.